### PR TITLE
default contentBase option to '' (empty string)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `rollup-plugin-serve` will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Default `contentBase` to current project folder
 
 ## [0.1.0] - 2016-09-29
 ### Added

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { resolve } from 'path'
 import mime from 'mime'
 import opener from 'opener'
 
-export default function serve (options = {}) {
+export default function serve (options = { contentBase: '' }) {
   if (Array.isArray(options) || typeof options === 'string') {
     options = { contentBase: options }
   }


### PR DESCRIPTION
in order to make it work like README says and work without configuration