### PR TITLE
Allow to override path for historyApiFallback option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ serve({
   // Set to true to return index.html instead of 404
   historyApiFallback: false,
 
+  // Return override.html instead of 404
+  historyApiFallback: '/override.html',
+
   // Options used in setting up server
   host: 'localhost',
   port: 10001,

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,8 @@ export default function serve (options = { contentBase: '' }) {
           }
         })
       } else if (options.historyApiFallback) {
-        readFileFromContentBase(options.contentBase, '/index.html', function (error, content, filePath) {
+        var fallbackPath = typeof options.historyApiFallback === 'string' ? options.historyApiFallback : '/index.html'
+        readFileFromContentBase(options.contentBase, fallbackPath, function (error, content, filePath) {
           if (error) {
             notFound(response, filePath)
           } else {


### PR DESCRIPTION
It will be nice to have an ability to override path for `historyApiFallback` option, e.g. serve `my.html` instead of hardcoded `index.html` on 404.