### PR TITLE
Release http server on rollup reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-serve",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Serve your rolled up bundle",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import { resolve } from 'path'
 import mime from 'mime'
 import opener from 'opener'
 
+let server
+
 export default function serve (options = { contentBase: '' }) {
   if (Array.isArray(options) || typeof options === 'string') {
     options = { contentBase: options }
@@ -64,8 +66,12 @@ export default function serve (options = { contentBase: '' }) {
     })
   }
 
+  // release previous server instance if rollup is reloading configuration in watch mode
+  if (server) {
+    server.close()
+  }
+
   // If HTTPS options are available, create an HTTPS server
-  let server
   if (options.https) {
     server = createHttpsServer(options.https, requestListener).listen(options.port, options.host)
   } else {


### PR DESCRIPTION
Release http server on rollup reload + bump minor version up

Fixes: 

- https://github.com/thgh/rollup-plugin-serve/issues/27
- https://github.com/thgh/rollup-plugin-serve/issues/28