### PR TITLE
add default value to contentBase when it is not passed in options object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ function serve (options = { contentBase: '' }) {
   if (Array.isArray(options) || typeof options === 'string') {
     options = { contentBase: options }
   }
-  options.contentBase = Array.isArray(options.contentBase) ? options.contentBase : [options.contentBase]
+  options.contentBase = Array.isArray(options.contentBase) ? options.contentBase : [(options.contentBase || '')]
   options.host = options.host || 'localhost'
   options.port = options.port || 10001
   options.headers = options.headers || {}


### PR DESCRIPTION
When ever options object is passed without defined contentBase property it will cause a crash when serve function is called.
In order to avoid the following situation [undefined], adding default of an empty string.