### PR TITLE
removed options.host='localhost'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ function serve (options = { contentBase: '' }) {
     options = { contentBase: options }
   }
   options.contentBase = Array.isArray(options.contentBase) ? options.contentBase : [options.contentBase]
-  options.host = options.host || 'localhost'
   options.port = options.port || 10001
   options.headers = options.headers || {}
   options.https = options.https || false
@@ -82,7 +81,7 @@ function serve (options = { contentBase: '' }) {
         running = true
 
         // Log which url to visit
-        const url = (options.https ? 'https' : 'http') + '://' + options.host + ':' + options.port
+        const url = (options.https ? 'https' : 'http') + '://' + (options.host || 'localhost') + ':' + options.port
         options.contentBase.forEach(base => {
           console.log(green(url) + ' -> ' + resolve(base))
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,10 +854,10 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
-mime@2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+mime@>=2.0.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
I had a scenario where forcing options.host='localhost' caused the server to fail. Letting http handle the default case cleaned this up. This is the same way that the "serve" package handles an unset options.host.