### PR TITLE
Allow specifying the full path of the page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,11 @@ function serve (options = { contentBase: '' }) {
 
         // Open browser
         if (options.open) {
-          opener(url + options.openPage)
+          if (/https?:\/\/.+/.test(options.openPage)) {
+            opener(options.openPage)
+          } else {
+            opener(url + options.openPage)
+          }
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -854,10 +854,10 @@ magic-string@^0.14.0:
   dependencies:
     vlq "^0.2.1"
 
-mime@2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+mime@>=2.0.3:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Here is my use-case:

I need the host to be `0.0.0.0` so I can access the server from other computers on the network (eg to test my website on mobile devices).
However currently if I set `host` to `0.0.0.0` my browser will open and broadcast the request to the whole network. I might get a response from another server. This feature would allow me to open `http://127.0.0.1` instead of `http://0.0.0.0` and avoid this issue.