### PR TITLE
Added mimeTypes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ serve({
   headers: {
     'Access-Control-Allow-Origin': '*',
     foo: 'bar'
+  },
+
+  // set custom mime types, usage https://github.com/broofa/mime#mimedefinetypemap-force--false
+  mimeTypes: {
+    'application/javascript': ['js_commonjs-proxy']
   }
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,10 @@ function serve (options = { contentBase: '' }) {
   options.openPage = options.openPage || ''
   mime.default_type = 'text/plain'
 
+  if (options.mimeTypes) {
+    mime.define(options.mimeTypes)
+  }
+
   const requestListener = (request, response) => {
     // Remove querystring
     const urlPath = decodeURI(request.url.split('?')[0])

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ function green (text) {
   return '\u001b[1m\u001b[32m' + text + '\u001b[39m\u001b[22m'
 }
 
-function closeServerOnTermination() {
+function closeServerOnTermination () {
   const terminationSignals = ['SIGINT', 'SIGTERM', 'SIGQUIT', 'SIGHUP']
   terminationSignals.forEach(signal => {
     process.on(signal, () => {

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ function serve (options = { contentBase: '' }) {
   mime.default_type = 'text/plain'
 
   if (options.mimeTypes) {
-    mime.define(options.mimeTypes)
+    mime.define(options.mimeTypes, true)
   }
 
   const requestListener = (request, response) => {


### PR DESCRIPTION
Option mirroring webpack dev server `mimeTypes` option  
https://webpack.js.org/configuration/dev-server/#devservermimetypes-

implemented following the instructions on `mime` repo  
https://github.com/broofa/mime#mimedefinetypemap-force--false