### PR TITLE
Feature: add `onListening` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ serve({
   mimeTypes: {
     'application/javascript': ['js_commonjs-proxy']
   }
+
+  // execute function after server has begun listening
+  onListening: (server) => {
+    const address = server.getAddress()
+    const host = address.host === '::' ? 'localhost' : address.host
+    console.log(`Server listening at http://${host}:${address.port}/`)
+  }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ serve({
   }
 
   // execute function after server has begun listening
-  onListening: (server) => {
+  onListening: function (server) {
     const address = server.getAddress()
     const host = address.host === '::' ? 'localhost' : address.host
-    console.log(`Server listening at http://${host}:${address.port}/`)
+    // by using a bound function, we can access options as `this`
+    const protocol = this.https ? 'https' : 'http'
+    console.log(`Server listening at ${protocol}://${host}:${address.port}/`)
   }
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ function serve (options = { contentBase: '' }) {
   options.headers = options.headers || {}
   options.https = options.https || false
   options.openPage = options.openPage || ''
+  options.onListening = options.onListening || function noop() { }
   mime.default_type = 'text/plain'
 
   if (options.mimeTypes) {
@@ -74,9 +75,15 @@ function serve (options = { contentBase: '' }) {
 
   // If HTTPS options are available, create an HTTPS server
   if (options.https) {
-    server = createHttpsServer(options.https, requestListener).listen(options.port, options.host)
+    server = createHttpsServer(options.https, requestListener)
+    server.listen(options.port, options.host, () => {
+      options.onListening(server)
+    })
   } else {
-    server = createServer(requestListener).listen(options.port, options.host)
+    server = createServer(requestListener)
+    server.listen(options.port, options.host, () => {
+      options.onListening(server)
+    })
   }
 
   // Assemble url for error and info messages
@@ -178,6 +185,7 @@ export default serve
  * @property {string|boolean} [historyApiFallback] Path to fallback page. Set to `true` to return index.html (200) instead of error page (404)
  * @property {string} [host='localhost'] Server host (default: `'localhost'`)
  * @property {number} [port=10001] Server port (default: `10001`)
+ * @property {function} [onListening] Execute a function when server starts listening for connections on a port
  * @property {ServeOptionsHttps} [https=false] By default server will be served over HTTP (https: `false`). It can optionally be served over HTTPS
  * @property {{[header:string]: string}} [headers] Set headers
  */

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function serve (options = { contentBase: '' }) {
   options.headers = options.headers || {}
   options.https = options.https || false
   options.openPage = options.openPage || ''
-  options.onListening = options.onListening || function noop() { }
+  options.onListening = options.onListening || function noop () { }
   mime.default_type = 'text/plain'
 
   if (options.mimeTypes) {

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -1,5 +1,18 @@
 import serve from '../src/index.js'
 
+const testOnListening = () => {
+  const timeout = 3
+  const timer = setTimeout(() => {
+    const msg = `onListening was not called within ${timeout}s`
+    console.error(msg)
+    throw new Error(msg)
+  }, timeout * 1000)
+  return (server) => {
+    clearTimeout(timer)
+    console.log('onListening works', server.address())
+  }
+}
+
 export default {
   input: 'entry.js',
   output: {
@@ -11,7 +24,8 @@ export default {
       open: true,
       openPage: '/frames.html',
       historyApiFallback: '/fallback.html',
-      contentBase: ['.', 'base1', 'base2']
+      contentBase: ['.', 'base1', 'base2'],
+      onListening: testOnListening(),
     })
   ]
 }


### PR DESCRIPTION
As mentioned in #68, this feature adds a callback that can be executed after the server begins listening, passing in the server itself. This matches [Webpack dev-server's `onListening`](https://webpack.js.org/configuration/dev-server/#devserveronlistening) hook.