### PR TITLE
Update onListening example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ serve({
 
   // execute function after server has begun listening
   onListening: function (server) {
-    const address = server.getAddress()
-    const host = address.host === '::' ? 'localhost' : address.host
+    const address = server.address()
+    const host = address.address === '::' ? 'localhost' : address.address
     // by using a bound function, we can access options as `this`
     const protocol = this.https ? 'https' : 'http'
     console.log(`Server listening at ${protocol}://${host}:${address.port}/`)


### PR DESCRIPTION
I tried using the code in the `onListening` example, but was getting this error:
```
TypeError: server.getAddress is not a function
    at Object.onListening (<redacted>/rollup.config.js:45:32)
    at Server.<anonymous> (<redacted>/node_modules/rollup-plugin-serve/dist/index.cjs.js:85:74)
    at Object.onceWrapper (events.js:286:20)
```

After some troubleshooting, I noticed that `server.getAddress()` has been renamed to [`server.address()`](https://nodejs.org/api/net.html#net_server_address). Additionally, the `host` property of the returned object has been renamed to `address`. Making these changed allowed me to run the code successfully.

I wanted to update it here as well to save people some troubleshooting time :slightly_smiling_face:.