### PR TITLE
add customRoute option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,20 @@ serve({
     foo: 'bar'
   },
 
+  customRoute: {
+    url: '/reset',
+    method: 'POST',
+    handler: function (request, response) {
+      res.writeHead(200, { 'Content-Type': 'text/plain' })
+      res.write('<html>OK</html>')
+      res.end()
+    }
+  },
+
   // set custom mime types, usage https://github.com/broofa/mime#mimedefinetypemap-force--false
   mimeTypes: {
     'application/javascript': ['js_commonjs-proxy']
-  }
+  },
 
   // execute function after server has begun listening
   onListening: function (server) {

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,14 @@ function serve (options = { contentBase: '' }) {
     // Don't allow path traversal
     const urlPath = posix.normalize(unsafePath)
 
+    // Call custom handler if defined
+    if (options.customRoute) {
+      const { method, url, handler } = options.customRoute
+      if (urlPath === url && request.method === method) {
+        return handler(request, response)
+      }
+    }
+
     Object.keys(options.headers).forEach((key) => {
       response.setHeader(key, options.headers[key])
     })
@@ -181,6 +189,10 @@ export default serve
  * @property {function} [onListening] Execute a function when server starts listening for connections on a port
  * @property {ServeOptionsHttps} [https=false] By default server will be served over HTTP (https: `false`). It can optionally be served over HTTPS
  * @property {{[header:string]: string}} [headers] Set headers
+ * @property {Object} [customRoute] Setup a custom handler for a single path / HTTP verb
+ * @property {string} [customRoute.method] HTTP verb to intercept
+ * @property {string} [customRoute.url] URI path (relative)
+ * @property {string} [customRoute.handler] A function to receive (req, res) as args and handle the request
  */
 
 /**


### PR DESCRIPTION
I have a need to register a custom handler (for integration functionality with our backend) for a specific route while I'm developing with rollup and this seemed like the simplest place to put it. Is this a reasonable option to add?