### PR TITLE
feat: expose `contentBasePublicPath`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,12 @@ export interface RollupServeOptions {
   contentBase?: string | string[]
 
   /**
+   * URL path prefix applied to all requests.
+   * E.g. If `contentBasePublicPath="/foo/bar"` and a request is made to `/foo/bar/baz.js`, `baz.js` will be returned from `contentBase`.
+   */
+  contentBasePublicPath?: string
+
+  /**
    * Set to `true` to return index.html (200) instead of error page (404)
    * or path to fallback page
    */

--- a/test/frames.html
+++ b/test/frames.html
@@ -27,14 +27,30 @@
     <td><iframe src="error.html"></iframe></td>
   </tr>
   <tr>
+    <td>/foo/bar</td>
+    <td><iframe src="/foo/bar"></iframe></td>
+    <td><iframe src="/foo/bar/"></iframe></td>
+    <td><iframe src="/foo/bar/error.html"></iframe></td>
+  </tr>
+  <tr>
     <td>./base1</td>
     <td><iframe src="./base1"></iframe></td>
     <td><iframe src="./base1/"></iframe></td>
   </tr>
   <tr>
+    <td>/foo/bar/base1</td>
+    <td><iframe src="/foo/bar/base1"></iframe></td>
+    <td><iframe src="/foo/bar/base1/"></iframe></td>
+  </tr>
+  <tr>
     <td>./base2</td>
     <td><iframe src="./base2"></iframe></td>
     <td><iframe src="./base2/"></iframe></td>
+  </tr>
+  <tr>
+    <td>/foo/bar/base2</td>
+    <td><iframe src="/foo/bar/base2"></iframe></td>
+    <td><iframe src="/foo/bar/base2/"></iframe></td>
   </tr>
   <tr>
     <th></th>
@@ -49,9 +65,21 @@
     <td><iframe src="./base2/test1.html"></iframe></td>
   </tr>
   <tr>
+    <td>/foo/bar/test1.html</td>
+    <td><iframe src="/foo/bar/test1.html"></iframe></td>
+    <td><iframe src="/foo/bar//base1/test1.html"></iframe></td>
+    <td><iframe src="/foo/bar//base2/test1.html"></iframe></td>
+  </tr>
+  <tr>
     <td>test2.html</td>
     <td><iframe src="./test2.html"></iframe></td>
     <td><iframe src="./base1/test2.html"></iframe></td>
     <td><iframe src="./base2/test2.html"></iframe></td>
+  </tr>
+  <tr>
+    <td>/foo/bar/test2.html</td>
+    <td><iframe src="/foo/bar//test2.html"></iframe></td>
+    <td><iframe src="/foo/bar//base1/test2.html"></iframe></td>
+    <td><iframe src="/foo/bar//base2/test2.html"></iframe></td>
   </tr>
 </table>

--- a/test/rollup.config.js
+++ b/test/rollup.config.js
@@ -28,6 +28,7 @@ export default {
       openPage: '/frames.html',
       historyApiFallback: '/fallback.html',
       contentBase: ['.', 'base1', 'base2'],
+      contentBasePublicPath: '/foo/bar',
       onListening: testOnListening(),
     })
   ]


### PR DESCRIPTION
* Add the option to specify a `contentBasePublicPath` which prepends the asset path to serve.
* Updated the docs to detail the new param.
* Added additional tests to cover usage of the new param.